### PR TITLE
Prefers log4j as spark's logger works better with it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,6 @@ subprojects { subproject ->
         testCompile 'junit:junit:4.12'
         testCompile 'org.mockito:mockito-all:1.10.19'
         testCompile "org.scalatest:scalatest_${scalaInterfaceVersion}:2.2.5"
-        testRuntime "org.slf4j:slf4j-simple:${commonVersions.slf4j}"
     }
 }
 

--- a/cassandra/build.gradle
+++ b/cassandra/build.gradle
@@ -1,7 +1,11 @@
 apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'org.openzipkin.dependencies.spark.cassandra.ZipkinDependenciesJob'
-test.maxParallelForks = 1
+
+test {
+    maxParallelForks 1
+    systemProperty 'log4j.configuration', 'org/apache/spark/log4j-defaults.properties'
+}
 
 ext {
     versions = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -37,6 +37,6 @@ subprojects { subproject ->
         // Log4j is bound by Spark
         exclude group: "ch.qos.logback"
         // don't loop slf4j-log4j-slf4j
-        exclude module: "slf4j-log4j12"
+        exclude module: "log4j-over-slf4j"
      }
 }


### PR DESCRIPTION
This configures our build so that both `./gradle check` and
`./gradle run` operate without log configuraion errors.

Logging dependency complexity and behavior of `o.a.s.Logging` result in
fragile configuration. For example, you cannot opt out of slf4j or
log4j. In other words, you need to use both, and in a particular way or
you'll end up with CNFE.

Fixes #8