### PR TITLE
Implements shadow jar and backfills README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,43 @@ matrix:
   include:
     - jdk: "oraclejdk8"
       env: GRADLE_OPTS="-Dorg.gradle.daemon=false -Xms2G -Xmx2G -Xss512k -XX:MetaspaceSize=256m"
-
 # These directories are cached to S3 at the end of the build
 cache:
   directories:
     - $HOME/.gradle/wrapper
     - $HOME/.gradle/native
     - $HOME/.gradle/daemon
-    - $HOME/.gradle/caches/jars-1
     - $HOME/.gradle/caches/2.9
+    - $HOME/.gradle/caches/jars-1
     - $HOME/.gradle/caches/modules-2
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/637e968b45032d16ee26
+    on_success: change
+    on_failure: always
+    on_start: false
+
+env:
+  global:
+  - secure: CEz4O1RmixHJno2A/oUL/zF8WKlgmmUKbu78xrnC80G0CsxOx7eJa3RSVV4NA5uoy4eVvMZS3CsWYXpfl2XTfdkQsgGEQDBbBNaQX/y0oBBusqT3bzVmWu2Lh90zFmh8iWylvhOadIUhe/D+jfKKZrCfXjTekRiNC/oYPzEB16w=
+  - secure: hP05qbQEDObdiu3LivKfeK4tA9zV4i2Q4RcGhB4ufGE54nTSRfHeLuloVT1frP8jHeBB3w3w7CFTL6rtV94uCPy3iTpvqXrJJLlnP+8WF2EISzhAvA9oG0J4XxSXeFZ2+5xF7FbHFCCs7cwmJr5SOr15JT152T4geP5WJHlSysc=
+  - secure: AWjkKlDz6vvzOHtz/ufK2ahEZNkMVpBosovi0K+J715mw6GjhYav4HfORc4PmuV55uiXZ8pxhFEAS1x4Aq4VnOndE9vti0azBtxopwvcx9ZmDSOzSx62ovTxV9PwtQ8KC0wHFE0B5N2ENhhly/A4mvoNPEv5EodF/l1JzfSfXEg=
+  - secure: CR3d3i2qUuMqVxA1r8+mSsPXTEBp74bKShSLNwNm2mwYa0TSNNx0tnD5kkTJYKxQYmrRIwKqDFZdkD3hLrCXbp1bpI5XbkJL/fMEdCdbiuOo1xOr3q4oZEUSfige9RTOdUudII3JO1RcL8fPdEwjRQZut4Rqf6ueGqNbilMRSjU=
+  - secure: Vxl1MpMeWktJNCRbhsMUn5M8gzlyaqt+bYAzpe9gics/NmCFNNviDY/YsxcLJ0gCv5ZD4sw/L7dLE490fmAGzlq5i1gViNJ2gnDmr5benizhcnyc+h2BtUn9+uYOKO4sRxcVTL7WOfxAQ+S2/SvmMYVP2MJ9cqVbjAhtEF4d8zI=
+  - secure: a14BeUrZ0vh3Zqu2bLTPqsDXoxdbbqF6yE07bnwo0PELypOzkCSHc1yWOv/gt0hOmSDe1QlvCnx1O3ChafzxsuhR275Zd1jfv28YjiprMhssJo1wFQcf4z/ha4msHk2RP09jr/ILVIQqal4MWVvob5mH8fJxUy57hXcn+dZPqw4=
+  - secure: itpof2Yfx1j9T9uuF9+nKISFKfYVmZKQav4gVmELDop4L6W0uysdFAkCJrDXd6lXMSVmjEGRm+7O+EERUH1FGsMD6b8iyKHVWQzNwXkyhyZUe+8C7s6QWpPPw8ycNNZj6/vV2oDeuoDaVi2/yqjS2+r5hHdlojNB1/wL7qLoF8M=
+
+before_install:
+  - git config --global user.email "${GH_USER_EMAIL}"
+  - git config --global user.name "${GH_USER}"
+
+# Skip `./gradlew assemble`
+install: /bin/true
+
+before_script:
+  - git remote set-url origin "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git"
+
+script:
+  - ./travis/publish.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,43 @@
 # zipkin-dependencies-spark
 
-Spark job that aggregates zipkin spans for use in the UI
+This module is a Spark job that will collect spans from your datastore (only Cassandra is supported yet),
+analyse them aggregate the data and store it for later presentation in the [web UI](https://github.com/openzipkin/zipkin/tree/master/zipkin-web) (ex. http://localhost:8080/dependency).
 
-## Running
+## Running locally
+To start a job against against cassandra listening on localhost:9042, in Spark's standalone mode.
 
-`./gradlew run`
+```bash
+$ ./gradlew run
+```
+
+## Configuration
+
+`zipkin-dependencies-spark` applies configuration parameters through environment variables.
+Currently, only [cassandra](https://github.com/openzipkin/zipkin/blob/master/zipkin-cassandra/README.md) span storage is supported.
+
+Below are environment variable definitions.
+
+    * `SPARK_MASTER`: Spark master to submit the job to; Defaults to `local[*]`
+    * `CASSANDRA_KEYSPACE`: Keyspace zipkin schema exists in; Defaults to `zipkin`
+    * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails
+    * `CASSANDRA_HOST`: A host in your cassandra cluster; Defaults to `127.0.0.1`
+    * `CASSANDRA_PORT`: The port of `CASSANDRA_HOST`; Defaults to `9042`
+
+Example usage:
+
+```bash
+$ CASSANDRA_USER=user CASSANDRA_PASS=pass ./gradlew run
+```
+
+## Building and running a fat jar
+
+```bash
+$ ./gradlew build
+```
+This will build a fat jar `./cassandra/build/libs/cassandra-*-all.jar`.
+
+Run it, specifying any environment variables you wish to apply.
+
+```bash
+$ CASSANDRA_HOST=remotecluster1 java -jar ./cassandra/build/libs/cassandra-*-all.jar
+```

--- a/build.gradle
+++ b/build.gradle
@@ -226,23 +226,6 @@ subprojects { subproject ->
         maven { url 'https://maven.twttr.com/' }
     }
 
-    configurations {
-        spark
-    }
-
-    idea {
-        module {
-            scopes.COMPILE.plus += [ configurations.spark ]
-        }
-    }
-
-    sourceSets {
-        main.compileClasspath += configurations.spark
-        main.runtimeClasspath += configurations.spark
-        test.compileClasspath += configurations.spark
-        test.runtimeClasspath += configurations.spark
-    }
-
     dependencies {
         testCompile 'junit:junit:4.12'
         testCompile 'org.mockito:mockito-all:1.10.19'

--- a/cassandra/build.gradle
+++ b/cassandra/build.gradle
@@ -14,11 +14,18 @@ ext {
 }
 
 dependencies {
-    spark "org.apache.spark:spark-core_${scalaInterfaceVersion}:${commonVersions.spark}"
+    compile "org.apache.spark:spark-core_${scalaInterfaceVersion}:${commonVersions.spark}"
     compile "com.datastax.spark:spark-cassandra-connector_${scalaInterfaceVersion}:${versions.cassandraConnector}"
     compile "io.zipkin:zipkin-cassandra:${commonVersions.zipkin}"
     testCompile "io.zipkin:zipkin-common:${commonVersions.zipkin}:test"
 }
+
+shadowJar {
+    zip64 true // spark + zipkin-finagle + scala = lots and lots of classes!
+    append('reference.conf') // merge akka resources
+}
+tasks.build.dependsOn(shadowJar)
+artifacts.zipkinUpload shadowJar
 
 configurations.all {
     resolutionStrategy {

--- a/cassandra/src/main/scala/org/openzipkin/dependencies/spark/cassandra/ZipkinDependenciesJob.scala
+++ b/cassandra/src/main/scala/org/openzipkin/dependencies/spark/cassandra/ZipkinDependenciesJob.scala
@@ -58,7 +58,7 @@ object ZipkinDependenciesJob {
     Span(id = span.id, traceId = span.traceId, parentId = span.parentId, serviceName = span.serviceName, annotations)
   }
 
-  val keyspace = sys.env.getOrElse("ZIPKIN_KEYSPACE", "zipkin")
+  val keyspace = sys.env.getOrElse("CASSANDRA_KEYSPACE", "zipkin")
   val cassandraProperties = Map(
     "spark.cassandra.connection.host" -> sys.env.getOrElse("CASSANDRA_HOST", "127.0.0.1"),
     "spark.cassandra.connection.port" -> sys.env.getOrElse("CASSANDRA_PORT", "9042"),

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -ex
+
+function heartbeat() {
+  # Some operations (for example Bintray GPG signing) run for a long time without output,
+  # causing Travis to time out the build. This is an ugly hack to work around that.
+  hard_timeout=3600  # 1 hour
+  heartbeat_interval=10
+  counter=0
+  while [[ $counter -lt $hard_timeout ]] && kill -0 "$$" 2>/dev/null; do
+    echo "(heartbeat $counter)"
+	counter=$(($counter + $heartbeat_interval))
+	sleep $heartbeat_interval
+  done &
+}
+
+function increment_version() {
+  # TODO this would be cleaner in release.versionPatterns
+  local v=$1
+  if [ -z $2 ]; then
+     local rgx='^((?:[0-9]+\.)*)([0-9]+)($)'
+  else
+     local rgx='^((?:[0-9]+\.){'$(($2-1))'})([0-9]+)(\.|$)'
+     for (( p=`grep -o "\."<<<".$v"|wc -l`; p<$2; p++)); do
+        v+=.0; done; fi
+  val=`echo -e "$v" | perl -pe 's/^.*'$rgx'.*$/$2/'`
+  echo "$v" | perl -pe s/$rgx.*$'/${1}'`printf %0${#val}s $(($val+1))`/
+}
+
+function build_started_by_tag(){
+  if [ "${TRAVIS_TAG}" == "" ]; then
+    echo "[Publishing] This build was not started by a tag, publishing"
+    return 1
+  else
+    echo "[Publishing] This build was started by the tag ${TRAVIS_TAG}, creating release commits"
+    return 0
+  fi
+}
+
+function is_pull_request(){
+  if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    echo "[Not Publishing] This is a Pull Request"
+    return 0
+  else
+    echo "[Publishing] This is not a Pull Request"
+    return 1
+  fi
+}
+
+function is_travis_branch_master(){
+  if [ "${TRAVIS_BRANCH}" = master ]; then
+    echo "[Publishing] Travis branch is master"
+    return 0
+  else
+    echo "[Not Publishing] Travis branch is not master"
+    return 1
+  fi
+}
+
+function check_travis_branch_equals_travis_tag(){
+  #Weird comparison comparing branch to tag because when you 'git push --tags'
+  #the branch somehow becomes the tag value
+  #github issue: https://github.com/travis-ci/travis-ci/issues/1675
+  if [ "${TRAVIS_BRANCH}" != "${TRAVIS_TAG}" ]; then
+    echo "Travis branch does not equal Travis tag, which it should, bailing out."
+    echo "  github issue: https://github.com/travis-ci/travis-ci/issues/1675"
+    exit 1
+  else
+    echo "[Publishing] Branch (${TRAVIS_BRANCH}) same as Tag (${TRAVIS_TAG})"
+  fi
+}
+
+function publish(){
+  echo "[Publishing] Publishing..."
+  PUBLISHING=true ./gradlew --info --stacktrace zipkinUpload
+  echo "[Publishing] Done"
+}
+
+function do_gradle_release(){
+  # TODO this would be cleaner in release.versionPatterns
+  major_minor_revision=$(echo "$TRAVIS_TAG" | cut -f1 -d-)
+  qualifier=$(echo "$TRAVIS_TAG" | cut -f2 -d- -s)
+
+  # do not increment if the version is tentative ex. 1.0.0-rc1
+  if [[ -n "$qualifier" ]]; then
+    new_version=${major_minor_revision}
+  else
+    new_version=$(increment_version "${major_minor_revision}")
+  fi
+  new_version="${new_version}-SNAPSHOT"
+
+  echo "[Publishing] Creating release commits"
+  echo "[Publishing]   Release version: ${TRAVIS_TAG}"
+  echo "[Publishing]   Post-release version: ${new_version}"
+
+  git checkout -B master
+
+  PUBLISHING=true ./gradlew --info --stacktrace release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}
+  echo "[Publishing] Done"
+}
+
+function run_tests(){
+  echo "[Not Publishing] Running tests then exiting."
+  ./gradlew check
+}
+
+#----------------------
+# MAIN
+#----------------------
+action=run_tests
+
+if ! is_pull_request; then
+  if build_started_by_tag; then
+    check_travis_branch_equals_travis_tag
+    action=do_gradle_release
+  elif is_travis_branch_master; then
+    action=publish
+  fi
+fi
+
+heartbeat
+$action


### PR DESCRIPTION
This corrects shadow configuration and backfills documentation on how to
use it.

The shadow jar was not configured correctly, mostly due to the "spark"
scope, which was not necessary to call out. This removes that scope and
defers to "compile". The impact is that if a user expects to exclude
spark, or handle it differently, they should just exclude the transitive
dep.

This also renames the env variable `ZIPKIN_KEYSPACE` to
`CASSANDRA_KEYSPACE`. This properly aligns the namespace to upstream and
other cassandra-specific properties.