### PR TITLE
Changes package name to io.zipkin

### DIFF
--- a/cassandra/build.gradle
+++ b/cassandra/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
-mainClassName = 'org.openzipkin.dependencies.spark.cassandra.ZipkinDependenciesJob'
+mainClassName = 'io.zipkin.dependencies.spark.cassandra.ZipkinDependenciesJob'
 
 test {
     maxParallelForks 1

--- a/cassandra/src/main/scala/io/zipkin/dependencies/spark/cassandra/DependenciesInfo.scala
+++ b/cassandra/src/main/scala/io/zipkin/dependencies/spark/cassandra/DependenciesInfo.scala
@@ -1,4 +1,4 @@
-package org.openzipkin.dependencies.spark.cassandra
+package io.zipkin.dependencies.spark.cassandra
 
 import com.twitter.zipkin.common.{DependencyLink, Dependencies}
 

--- a/cassandra/src/main/scala/io/zipkin/dependencies/spark/cassandra/ZipkinDependenciesJob.scala
+++ b/cassandra/src/main/scala/io/zipkin/dependencies/spark/cassandra/ZipkinDependenciesJob.scala
@@ -1,4 +1,4 @@
-package org.openzipkin.dependencies.spark.cassandra
+package io.zipkin.dependencies.spark.cassandra
 
 import java.util.concurrent.TimeUnit._
 

--- a/cassandra/src/test/scala/io/zipkin/dependencies/spark/CassandraFixture.scala
+++ b/cassandra/src/test/scala/io/zipkin/dependencies/spark/CassandraFixture.scala
@@ -1,4 +1,4 @@
-package org.openzipkin.dependencies.spark
+package io.zipkin.dependencies.spark
 
 import com.datastax.driver.core.Cluster
 import com.google.common.util.concurrent.Futures

--- a/cassandra/src/test/scala/io/zipkin/dependencies/spark/ZipkinDependenciesJobSpec.scala
+++ b/cassandra/src/test/scala/io/zipkin/dependencies/spark/ZipkinDependenciesJobSpec.scala
@@ -1,11 +1,11 @@
-package org.openzipkin.dependencies.spark
+package io.zipkin.dependencies.spark
 
 import com.twitter.util.Await._
 import com.twitter.zipkin.common.Span
 import com.twitter.zipkin.storage.DependencyStoreSpec
 import com.twitter.zipkin.storage.cassandra.{CassandraDependencyStore, CassandraSpanStore}
+import io.zipkin.dependencies.spark.cassandra.ZipkinDependenciesJob
 import org.junit.{AssumptionViolatedException, BeforeClass, Ignore, Test}
-import org.openzipkin.dependencies.spark.cassandra.ZipkinDependenciesJob
 
 object ZipkinDependenciesJobSpec {
 


### PR DESCRIPTION
Conventionally top-level package names correspond with a domain you own.
We don't own openzipkin.org, but we do own zipkin.io. This would also
be more helpful as we actually have a website there.

Fixes #5