### PR TITLE
Adds initial Elasticsearch support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 *.iws
 # .travis.yml installs things
 dsc-cassandra-*
+elasticsearch-2*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,17 @@
 sudo: required
 dist: trusty
 
-# Manually install cassandra until https://github.com/travis-ci/travis-ci/issues/3952
-# See https://github.com/openzipkin/zipkin/issues/706
 before_install:
+  # Manually install cassandra until https://github.com/travis-ci/travis-ci/issues/3952
+  # See https://github.com/openzipkin/zipkin/issues/706
   - curl -SL http://downloads.datastax.com/community/dsc-cassandra-2.2.7-bin.tar.gz | tar xz
   - dsc-cassandra-*/bin/cassandra > /dev/null
+  # Manually install elasticsearch until https://github.com/travis-ci/apt-source-whitelist/issues/190
+  - curl -SL https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.3/elasticsearch-2.3.3.tar.gz | tar xz
+  - elasticsearch-*/bin/elasticsearch -d > /dev/null
+  # parameters used during a release
   - git config --global user.email "${GH_USER_EMAIL}"
   - git config --global user.name "${GH_USER}"
-  # parameters used during a release
   - git config user.name "$GH_USER"
   - git config user.email "$GH_USER_EMAIL"
   # setup https authentication credentials, used by ./mvnw release:prepare

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ and store them for later presentation in the [web UI](https://github.com/openzip
 This job parses all traces in the current day in UTC time. This means you should schedule it to run
 just prior to midnight UTC.
 
-Currently, Zipkin [Cassandra](https://github.com/openzipkin/zipkin/blob/master/zipkin-storage/cassandra/README.md). 
-Elasticsearch and MySQL will be added shortly.
+Currently, Zipkin [Cassandra](https://github.com/openzipkin/zipkin/blob/master/zipkin-storage/cassandra/README.md) and
+[Elasticsearch](https://github.com/openzipkin/zipkin/blob/master/zipkin-storage/elasticsearch/README.md) schemas are supported. MySQL will be added shortly.
 
 ## Running locally
 
@@ -20,6 +20,8 @@ To start a job against against a local datastore, in Spark's standalone mode.
 $ ./mvnw -DskipTests clean install
 # Run the Cassandra job
 $ java -jar ./cassandra/target/zipkin-dependencies*-all.jar
+# Or run the Elasticsearch job
+$ java -jar ./elasticsearch/target/zipkin-dependencies*-all.jar
 ```
 
 ## Environment Variables
@@ -41,4 +43,20 @@ Example usage:
 
 ```bash
 $ CASSANDRA_USER=user CASSANDRA_PASS=pass java -jar ./cassandra/target/zipkin-dependencies*-all.jar
+```
+
+### Elasticsearch Storage
+The Elasticsearch binary is compatible with Zipkin's [Elasticsearch storage component](https://github.com/openzipkin/zipkin/tree/master/zipkin-storage/elasticsearch).
+
+    * `ES_INDEX`: The index prefix to use when generating daily index names. Defaults to zipkin.
+    * `ES_HOSTS`: A comma separated list of elasticsearch hostnodes to connect to, in host:port
+                  format. The port should be the transport port, not the http port. Defaults to
+                  "localhost:9300". Only one of these hosts needs to be available to fetch the
+                  remaining nodes in the cluster. It is recommended to set this to all the master
+                  nodes of the cluster.
+
+Example usage:
+
+```bash
+$ ES_HOSTS=host1:9300,host2:9300 java -jar ./elasticsearch/target/zipkin-dependencies*-all.jar
 ```

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <!-- TODO: change this group id to something like io.zipkin.dependencies -->
+    <groupId>io.zipkin</groupId>
+    <artifactId>zipkin-dependencies-spark-parent</artifactId>
+    <version>1.41.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-dependencies-spark-elasticsearch</artifactId>
+  <name>Zipkin Dependencies Spark: Elasticsearch</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <java.main.class>io.zipkin.dependencies.spark.elasticsearch.ElasticsearchDependenciesJob</java.main.class>
+    <elasticsearch.version>2.3.3</elasticsearch.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch-spark_${scala.binary.version}</artifactId>
+      <version>${elasticsearch.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <!-- optional will be included in the all-jar -->
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin-storage-elasticsearch</artifactId>
+      <version>${zipkin.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/elasticsearch/src/main/java/io/zipkin/dependencies/spark/elasticsearch/ElasticsearchDependenciesJob.java
+++ b/elasticsearch/src/main/java/io/zipkin/dependencies/spark/elasticsearch/ElasticsearchDependenciesJob.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin.dependencies.spark.elasticsearch;
+
+import com.google.common.collect.ImmutableMap;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.elasticsearch.spark.rdd.api.java.JavaEsSpark;
+import scala.Tuple2;
+import zipkin.Codec;
+import zipkin.DependencyLink;
+import zipkin.Span;
+import zipkin.internal.DependencyLinkSpan;
+import zipkin.internal.DependencyLinker;
+import zipkin.internal.MergeById;
+import zipkin.internal.moshi.JsonAdapter;
+import zipkin.internal.moshi.Moshi;
+
+import static zipkin.internal.Util.checkNotNull;
+import static zipkin.internal.Util.midnightUTC;
+
+public final class ElasticsearchDependenciesJob {
+
+  /** Runs with defaults, starting today */
+  public static void main(String[] args) {
+    new ElasticsearchDependenciesJob(new Builder()).run();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    String index = getEnv("ES_INDEX", "zipkin");
+
+    Map<String, String> sparkProperties = ImmutableMap.of(
+        "spark.ui.enabled", "false",
+        // avoids strange class not found bug on Logger.setLevel
+        "spark.akka.logLifecycleEvents", "true",
+        // don't die if there are no spans
+        "es.index.read.missing.as.empty", "true",
+        "es.nodes", getEnv("ES_HOSTS", "127.0.0.1") // ES_HOSTS is the env variable in zipkin
+    );
+
+    // local[*] master lets us run & test the job locally without setting a Spark cluster
+    String sparkMaster = getEnv("SPARK_MASTER", "local[*]");
+
+    // By default the job only works on traces whose first timestamp is today
+    long day = midnightUTC(System.currentTimeMillis());
+
+    /** The index prefix to use when generating daily index names. Defaults to "zipkin" */
+    public Builder index(String index) {
+      this.index = checkNotNull(index, "index");
+      return this;
+    }
+
+    /** Day (in epoch milliseconds) to process dependencies for. Defaults to today. */
+    public Builder day(long day) {
+      this.day = midnightUTC(day);
+      return this;
+    }
+
+    public ElasticsearchDependenciesJob build() {
+      return new ElasticsearchDependenciesJob(this);
+    }
+
+    Builder() {
+    }
+  }
+
+  final String index;
+  final long day;
+  final String dateStamp;
+  final SparkConf conf;
+
+  static final JsonAdapter<TraceId> traceIdReader =
+      new Moshi.Builder().build().adapter(TraceId.class);
+
+  static final class TraceId {
+    String traceId;
+  }
+
+  ElasticsearchDependenciesJob(Builder builder) {
+    this.index = builder.index;
+    this.day = builder.day;
+    this.dateStamp = new SimpleDateFormat("yyyy-MM-dd").format(new Date(builder.day));
+    this.conf = new SparkConf(true)
+        .setMaster(builder.sparkMaster)
+        .setAppName(getClass().getName());
+    for (Map.Entry<String, String> entry : builder.sparkProperties.entrySet()) {
+      conf.set(entry.getKey(), entry.getValue());
+    }
+  }
+
+  public void run() {
+    String bucket = index + "-" + dateStamp;
+
+    System.out.println("Processing spans from " + bucket + "/span");
+
+    JavaSparkContext sc = new JavaSparkContext(conf);
+    JavaRDD<Map<String, Object>> links = JavaEsSpark.esJsonRDD(sc, bucket + "/span")
+        .groupBy(pair -> traceIdReader.fromJson(pair._2).traceId)
+        .flatMap(pair -> toLinks(pair._2))
+        .mapToPair(link -> Tuple2.apply(Tuple2.apply(link.parent, link.child), link))
+        .reduceByKey((l, r) -> DependencyLink.create(l.parent, l.child, l.callCount + r.callCount))
+        .values()
+        .map(l -> ImmutableMap.<String, Object>of(
+            "parent", l.parent,
+            "child", l.child,
+            "id", l.parent + "|" + l.child,
+            "callCount", l.callCount
+        ));
+
+    System.out.println("Saving dependency links to " + bucket + "/dependencylink");
+    JavaEsSpark.saveToEs(links, bucket + "/dependencylink",
+        ImmutableMap.of("es.mapping.id", "id")); // unique id, which allows overwriting the link
+    System.out.println("Dependencies: " + links.collect());
+    sc.stop();
+  }
+
+  // static to avoid spark trying to serialize the enclosing class
+  static Iterable<DependencyLink> toLinks(Iterable<Tuple2<String, String>> rows) {
+    List<Span> spans = new LinkedList<>();
+    for (Tuple2<String, String> row : rows) {
+      spans.add(Codec.JSON.readSpan(row._2.getBytes()));
+    }
+    List<DependencyLinkSpan> linkSpans = new LinkedList<>();
+    for (Span s : MergeById.apply(spans)) {
+      linkSpans.add(DependencyLinkSpan.from(s));
+    }
+    return new DependencyLinker().putTrace(linkSpans.iterator()).link();
+  }
+
+  private static String getEnv(String key, String defaultValue) {
+    String result = System.getenv(key);
+    return result != null ? result : defaultValue;
+  }
+}

--- a/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
+++ b/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch;
+
+import com.google.common.util.concurrent.Futures;
+import io.zipkin.dependencies.spark.elasticsearch.ElasticsearchDependenciesJob;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import zipkin.Span;
+import zipkin.internal.Util;
+import zipkin.storage.DependenciesTest;
+
+public class ElasticsearchDependenciesTest extends DependenciesTest {
+  private final ElasticsearchStorage storage;
+  private final String index;
+
+  public ElasticsearchDependenciesTest() {
+    this.storage = ElasticsearchTestGraph.INSTANCE.storage.get();
+    this.index = ElasticsearchTestGraph.INSTANCE.index;
+  }
+
+  @Override protected ElasticsearchStorage storage() {
+    return storage;
+  }
+
+  @Override public void clear() {
+    storage.clear();
+  }
+
+  /**
+   * This processes the job as if it were a batch. For each day we had traces, run the job again.
+   */
+  @Override
+  public void processDependencies(List<Span> spans) {
+    Futures.getUnchecked(storage.guavaSpanConsumer().accept(spans));
+
+    Set<Long> days = new LinkedHashSet<>();
+    for (Span span : spans) {
+      days.add(Util.midnightUTC(span.timestamp / 1000));
+    }
+    for (long day : days) {
+      ElasticsearchDependenciesJob.builder().index(index).day(day).build().run();
+    }
+  }
+}

--- a/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
+++ b/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch;
+
+import org.junit.AssumptionViolatedException;
+import zipkin.Component.CheckResult;
+import zipkin.internal.LazyCloseable;
+
+enum ElasticsearchTestGraph {
+  INSTANCE;
+
+  final String index = "test_zipkin";
+
+  static {
+    ElasticsearchStorage.FLUSH_ON_WRITES = true;
+  }
+
+  final LazyCloseable<ElasticsearchStorage> storage = new LazyCloseable<ElasticsearchStorage>() {
+    public AssumptionViolatedException ex;
+
+    @Override protected ElasticsearchStorage compute() {
+      if (ex != null) throw ex;
+      ElasticsearchStorage result = new ElasticsearchStorage.Builder().index(index).build();
+      CheckResult check = result.check();
+      if (check.ok) return result;
+      throw ex = new AssumptionViolatedException(check.exception.getMessage());
+    }
+  };
+}

--- a/elasticsearch/src/test/resources/logback.xml
+++ b/elasticsearch/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="warn">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 
   <modules>
     <module>cassandra</module>
+    <module>elasticsearch</module>
   </modules>
 
   <properties>
@@ -37,7 +38,7 @@
 
     <scala.binary.version>2.11</scala.binary.version>
     <spark.version>1.6.2</spark.version>
-    <zipkin.version>1.4.1</zipkin.version>
+    <zipkin.version>1.4.2</zipkin.version>
     <logback.version>1.1.7</logback.version>
     <junit.version>4.12</junit.version>
     <assertj.version>3.5.1</assertj.version>
@@ -294,6 +295,13 @@
                       <include>**</include>
                     </includes>
                   </filter>
+                  <filter>
+                    <!-- elasticsearch -->
+                    <artifact>commons-httpclient:commons-httpclient</artifact>
+                    <includes>
+                      <include>**</include>
+                    </includes>
+                  </filter>
                   <!-- Prevent Invalid signature file digest for Manifest main attributes -->
                   <filter>
                     <artifact>*:*</artifact>
@@ -405,6 +413,7 @@
             <exclude>LICENSE</exclude>
             <exclude>**/*.md</exclude>
             <exclude>dsc-cassandra-*/**</exclude>
+            <exclude>elasticsearch-2*/**</exclude>
             <exclude>src/test/resources/**</exclude>
             <exclude>src/main/resources/**</exclude>
           </excludes>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -109,7 +109,8 @@ if ! is_pull_request && build_started_by_tag; then
   check_release_tag
 fi
 
-MYSQL_USER=root ./mvnw install -nsu
+# Use quiet as shade plugin creates too many logs for Travis: The log length has exceeded the limit of 4 MB
+./mvnw -q install -nsu
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
 if is_pull_request; then
@@ -117,19 +118,19 @@ if is_pull_request; then
 # If we are on master, we will deploy the latest snapshot or release version
 #   - If a release commit fails to deploy for a transient reason, delete the broken version from bintray and click rebuild
 elif is_travis_branch_master; then
-  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
+  ./mvnw -q --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
 
   # If the deployment succeeded, sync it to Maven Central. Note: this needs to be done once per project, not module, hence -N
 #
 #  TODO: commented out until we get the group ids sorted out.
 #
 #  if is_release_commit; then
-#    ./mvnw --batch-mode -s ./.settings.xml -nsu -N io.zipkin.centralsync-maven-plugin:centralsync-maven-plugin:sync
+#    ./mvnw -q --batch-mode -s ./.settings.xml -nsu -N io.zipkin.centralsync-maven-plugin:centralsync-maven-plugin:sync
 #  fi
 
 # If we are on a release tag, the following will update any version references and push a version tag for deployment.
 elif build_started_by_tag; then
   safe_checkout_master
-  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
+  ./mvnw -q --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
 fi
 


### PR DESCRIPTION
This is feature-parity with the cassandra version, and similarly uses
a connector (as opposed to zipkin classes) to do the Spark work.

Tested this works with Java 7, by running the [brave example](https://github.com/openzipkin/brave-resteasy-example), then the spark job.

```bash
$ /Library/Java/JavaVirtualMachines/jdk1.7.0_79.jdk/Contents/Home/bin/java -jar ./elasticsearch/target/zipkin-dependencies*-all.jar
Processing spans from zipkin-2016-07-17/span
16:37:10.039 [main] WARN  o.a.hadoop.util.NativeCodeLoader - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
16:37:10.125 [main] WARN  org.apache.spark.util.Utils - Your hostname, acole resolves to a loopback address: 127.0.0.1; using 192.168.1.10 instead (on interface en0)
16:37:10.126 [main] WARN  org.apache.spark.util.Utils - Set SPARK_LOCAL_IP if you need to bind to another address
Saving dependency links to zipkin-2016-07-17/dependencylink
Dependencies: [{parent=brave-resteasy-example, child=brave-resteasy-example, parent_child=brave-resteasy-example|brave-resteasy-example, callCount=1}]
```

Fixes #21