### PR TITLE
Renames ES_HOSTS to ES_NODES; adds ES_NODES_WAN_ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,15 @@ $ CASSANDRA_USER=user CASSANDRA_PASS=pass java -jar ./cassandra/target/zipkin-de
 The Elasticsearch binary is compatible with Zipkin's [Elasticsearch storage component](https://github.com/openzipkin/zipkin/tree/master/zipkin-storage/elasticsearch).
 
     * `ES_INDEX`: The index prefix to use when generating daily index names. Defaults to zipkin.
-    * `ES_HOSTS`: A comma separated list of elasticsearch hostnodes to connect to, in host:port
-                  format. The port should be the transport port, not the http port. Defaults to
-                  "localhost:9300". Only one of these hosts needs to be available to fetch the
+    * `ES_NODES`: A comma separated list of elasticsearch hosts advertising http on port 9200.
+                  Defaults to localhost. Only one of these hosts needs to be available to fetch the
                   remaining nodes in the cluster. It is recommended to set this to all the master
                   nodes of the cluster.
+    * `ES_NODES_WAN_ONLY`: Set to true to only use the values set in ES_NODES, for example if your
+                           elasticsearch cluster is in Docker. Defaults to false
 
 Example usage:
 
 ```bash
-$ ES_HOSTS=host1:9300,host2:9300 java -jar ./elasticsearch/target/zipkin-dependencies*-all.jar
+$ ES_NODES=host1:9200,host2:9200 java -jar ./elasticsearch/target/zipkin-dependencies*-all.jar
 ```

--- a/elasticsearch/src/main/java/io/zipkin/dependencies/spark/elasticsearch/ElasticsearchDependenciesJob.java
+++ b/elasticsearch/src/main/java/io/zipkin/dependencies/spark/elasticsearch/ElasticsearchDependenciesJob.java
@@ -57,7 +57,9 @@ public final class ElasticsearchDependenciesJob {
         "spark.akka.logLifecycleEvents", "true",
         // don't die if there are no spans
         "es.index.read.missing.as.empty", "true",
-        "es.nodes", getEnv("ES_HOSTS", "127.0.0.1") // ES_HOSTS is the env variable in zipkin
+        "es.nodes.wan.only", getEnv("ES_NODES_WAN_ONLY", "false"),
+        // NOTE: unlike zipkin, this uses the http port
+        "es.nodes", getEnv("ES_NODES", "127.0.0.1")
     );
 
     // local[*] master lets us run & test the job locally without setting a Spark cluster


### PR DESCRIPTION
`ES_NODES_WAN_ONLY` is a special flag that is useful in Docker as
it forces data to route through `ES_NODES`. Without this setting, data
nodes would be looked up via `http://$ES_NODES:9200/_nodes/http`. This
would return container ips that are not likely reachable. With these
changes, you can do the following:

```bash
$ ES_NODES=192.168.99.100 ES_NODES_WAN_ONLY=true java -jar ...
```

The other change is renaming ES_HOSTS to ES_NODES, as it is more
consistent with elasticsearch-hadoop property names.

See https://www.elastic.co/guide/en/elasticsearch/hadoop/current/cloud.html#_configure_the_connector_to_run_in_wan_mode